### PR TITLE
Remove duplicate Dependencys

### DIFF
--- a/Block/Like.php
+++ b/Block/Like.php
@@ -5,11 +5,9 @@
 
 namespace Pheme\Facebook\Block;
 
-use Magento\Framework\UrlInterface;
 use Magento\Store\Model\ScopeInterface;
 use Magento\Framework\View\Element\Template;
 use Magento\Framework\View\Element\Template\Context;
-use Magento\Framework\App\Config\ScopeConfigInterface;
 
 class Like extends Template
 {
@@ -27,19 +25,13 @@ class Like extends Template
 
     /**
      * @param \Magento\Framework\View\Element\Template\Context $context
-     * @param ScopeConfigInterface $scopeConfig
-     * @param UrlInterface $urlInterface
      * @param array $data
      */
     public function __construct(
         Context $context,
-        ScopeConfigInterface $scopeConfig,
-        UrlInterface $urlInterface,
         array $data
     ) {
         parent::__construct($context, $data);
-        $this->scopeConfig = $scopeConfig;
-        $this->urlInterface = $urlInterface;
     }
 
     public function getShowFaces()

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "magento/framework": "100.0.*"
     },
     "type": "magento2-module",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "license": [
         "BSD-3-Clause"
     ],


### PR DESCRIPTION
On setup:di:compile you get this error.

Incorrect dependency in class Pheme\Facebook\Block\Like in /data/www/repro/vendor/pheme/magento2-facebook-likes/Block/Like.php
\Magento\Framework\App\Config\ScopeConfigInterface already exists in context object
\Magento\Framework\UrlInterface already exists in context object

I have removed the to dependencies
